### PR TITLE
ERMN2019

### DIFF
--- a/global.R
+++ b/global.R
@@ -3,11 +3,12 @@
 Network<-"ERMN"
 
 NetworkURL<-switch(Network,
-                   ERMN=, GULN=, MIDN=, NCRN=, NETN = paste0('https://www.nps.gov/im/',tolower(Network),'/index.htm')
+                   ERMN=, ERMN2007=, GULN=, MIDN=, NCRN=, NETN = paste0('https://www.nps.gov/im/',tolower(Network),'/index.htm')
 )
 
 Years<-switch(Network,
               ERMN=list(Start=2011, End=2019),
+              ERMN2007=list(Start=2007, End=2012),
               #GULN=list(Start=NA, End=NA),
               MIDN=list(Start=2009, End=2018),
               NCRN=list(Start=2007, End=2017),
@@ -17,6 +18,7 @@ Years<-switch(Network,
 ## Note - first option listed for ExtraLayers will be chosen by default - "None" is highly recommended.
 ExtraLayers<-switch(Network,
                     ERMN=c(None="None"),
+                    ERMN2007=c(None="None"),
                     #GULN=c(None="None"),
                     MIDN=c(None="None"),
                     NCRN=c(None="None", "Ecoregions"="Ecoregions","Forested Areas"="Forested"),
@@ -25,6 +27,7 @@ ExtraLayers<-switch(Network,
 
 ProjectInfo<-switch(Network,
                     ERMN=includeHTML("./www/ERMN/ProjectInfo_ERMN.html"),
+                    ERMN2007=includeHTML("./www/ERMN2007/ProjectInfo_ERMN2007.html"),
                     #GULN=includeHTML("<h1>Add Me!</h1>"),
                     MIDN=includeHTML("./www/MIDN/ProjectInfo.html"),
                     NCRN=includeHTML("./www/NCRN/ProjectInfo.html"),
@@ -33,6 +36,7 @@ ProjectInfo<-switch(Network,
 
 Citations<-switch(Network,
                   ERMN=includeHTML("./www/ERMN/Citations_ERMN.html"),
+                  ERMN2007=includeHTML("./www/ERMN2007/Citations_ERMN2007.html"),
                   # GULN=includeHTML("<h1>Add Me!</h1>"),
                   MIDN=includeHTML("./www/MIDN/Citations.html"),
                   NCRN=includeHTML("./www/NCRN/Citations.html"),

--- a/global.R
+++ b/global.R
@@ -1,13 +1,13 @@
 #### Network Specific Settings ####
 
-Network<-"NCRN"
+Network<-"ERMN"
 
 NetworkURL<-switch(Network,
                    ERMN=, GULN=, MIDN=, NCRN=, NETN = paste0('https://www.nps.gov/im/',tolower(Network),'/index.htm')
 )
 
 Years<-switch(Network,
-              ERMN=list(Start=2011, End=2017),
+              ERMN=list(Start=2011, End=2019),
               #GULN=list(Start=NA, End=NA),
               MIDN=list(Start=2009, End=2018),
               NCRN=list(Start=2007, End=2017),

--- a/server.r
+++ b/server.r
@@ -13,7 +13,8 @@ library(jsonlite, pos=100)
 
 
 BirdData<-switch(Network,
-                 ERMN= importERMNbirds("./Data/ERMN_NewProtocol"),
+                 ERMN= importERMNbirds("./Data/ERMN"),
+                 ERMN2007= importERMNbirds2007("./Data/ERMN2007"),
                  GULN= importGULNbirds("./Data/GULN"),
                  MIDN= importMIDNbirds("./Data/MIDN"),
                  NCRN= importNCRNbirds("./Data/NCRN"),


### PR DESCRIPTION
Cleanup code to clarify two datasets to visualize for ERMN: ERMN2007 and ERMN. The ERMN dataset is the current and ongoing dataset, whereas ERMN2007 covers the period 2007-2012.

Also edited code to add 2018 and 2019 data to ERMN.